### PR TITLE
Remove -e option, set encoding to UTF-8

### DIFF
--- a/massmail
+++ b/massmail
@@ -53,11 +53,6 @@ Options:
   -s SEPARATOR      set field separator in parameter file,
                     default: ";"
 
-  -e ENCODING       set PARAMETER_FILE *and* BODY character set
-                    encoding, default: "UTF-8". Note that if you fuck
-                    up this one, your email will be full of rubbish:
-                    You have been warned!
-
   -f                fake run: don't really send emails, just print to
                     standard output what would be done. Don't be scared
                     if you can not read the body: it is base64 encoded
@@ -142,8 +137,6 @@ def parse_command_line_options(arguments):
     }
 
     for option, value in opts:
-        if option == "-e":
-            options['encoding'] = value
         if option == "-s":
             options['sep'] = value
         elif option == "-F":


### PR DESCRIPTION
Fixes #18.