### PR TITLE
Fixed do not send email by default bug

### DIFF
--- a/massmail
+++ b/massmail
@@ -143,7 +143,7 @@ def parse_command_line_options(arguments):
         if option == "-e":
             options['encoding'] = value
         if option == "-s":
-            options['sep'] = value
+            options['send'] = value
         elif option == "-F":
             options['from'] = value
         elif option == "-S":

--- a/massmail
+++ b/massmail
@@ -58,10 +58,8 @@ Options:
                     up this one, your email will be full of rubbish:
                     You have been warned!
 
-  -f                fake run: don't really send emails, just print to
-                    standard output what would be done. Don't be scared
-                    if you can not read the body: it is base64 encoded
-                    UTF8 text
+  -s                really send the mails, leaving this option untouched
+                    makes a dry run.
 
   -z SERVER         the SMTP server to use. This argument is required
 
@@ -129,7 +127,7 @@ def parse_command_line_options(arguments):
     # set default options
     options = {
         'sep': u';',
-        'fake': False,
+        'send': False,
         'from': '',
         'subject': '',
         'bcc': '',
@@ -157,8 +155,8 @@ def parse_command_line_options(arguments):
         elif option == "-h":
             print(USAGE)
             exit(0)
-        elif option == "-f":
-            options['fake'] = True
+        elif option == "-s":
+            options['send'] = True
         elif option == "-u":
             options['smtpuser'] = value
         elif option == "-p":
@@ -174,7 +172,7 @@ def parse_command_line_options(arguments):
     if len(options['from']) == 0:
         error('You must set a from address with option -F')
 
-    if options['server'] is None and not options['fake']:
+    if options['server'] is None and options['send']:
         error('You must set a SMTP server with option -z')
 
     if options['sep'] == ",":
@@ -260,10 +258,10 @@ def add_email_headers(options, msgs):
     return None
 
 def send_messages(options, msgs):
-    if not options['fake']:
+    if options['send']:
         server = smtplib.SMTP(options['server'], port=options['port'])
 
-    if options['smtpuser'] is not None and not options['fake']:
+    if options['smtpuser'] is not None and options['send']:
         server.starttls()
         server.login(options['smtpuser'], options['smtppassword'])
 
@@ -272,7 +270,7 @@ def send_messages(options, msgs):
         emails = [e.strip() for e in emailaddr.split(',')]
         if len(options['bcc']) > 0:
             emails.append(options['bcc'])
-        if options['fake']:
+        if not options['send']:
             print(msgs[emailaddr].as_string())
         else:
             try:
@@ -283,7 +281,7 @@ def send_messages(options, msgs):
             if len(out) != 0:
                 error(str(out))
 
-    if not options['fake']:
+    if options['send']:
         server.close()
 
 def main(arguments):

--- a/test_sending.py
+++ b/test_sending.py
@@ -67,7 +67,7 @@ def test_local_sending():
         massmail.add_email_headers(options, msgs)
         assert msgs['testrecv@test.org'].as_string() == expected_email.as_string()
 
-def test_fake_sending():
+def test_sending_fake_address():
     address = 'localhost:1025'
     with tempfile.NamedTemporaryFile('wt') as f:
         f.write('$EMAIL$;$VALUE$\ntestrecv@test;this is a test')
@@ -75,7 +75,7 @@ def test_fake_sending():
 
         with fake_smtp_server(address) as server:
             with replace_stdin('EMAIL=$EMAIL$\nVALUE=$VALUE$'):
-                massmail.main(['-F', 'fake@foobar.com',
+                massmail.main(['-F', 'fake@foobar.com', '-s',
                                '-z', address,
                                f.name])
 

--- a/test_sending.py
+++ b/test_sending.py
@@ -75,8 +75,8 @@ def test_sending_fake_address():
 
         with fake_smtp_server(address) as server:
             with replace_stdin('EMAIL=$EMAIL$\nVALUE=$VALUE$'):
-                massmail.main(['-F', 'fake@foobar.com', '-s',
-                               '-z', address,
+                massmail.main(['-F', 'fake@foobar.com',
+                               '-z', address, '-s', True,
                                f.name])
 
     output = server.stderr.read()


### PR DESCRIPTION
We removed the -f flag and added a -s flag which is required for sending the mail. Issue  #6 