### PR TITLE
Drops -e parameter, default encoding utf-8

### DIFF
--- a/massmail
+++ b/massmail
@@ -53,11 +53,6 @@ Options:
   -s SEPARATOR      set field separator in parameter file,
                     default: ";"
 
-  -e ENCODING       set PARAMETER_FILE *and* BODY character set
-                    encoding, default: "UTF-8". Note that if you fuck
-                    up this one, your email will be full of rubbish:
-                    You have been warned!
-
   -f                fake run: don't really send emails, just print to
                     standard output what would be done. Don't be scared
                     if you can not read the body: it is base64 encoded
@@ -122,7 +117,7 @@ def parse_command_line_options(arguments):
     Arguments are checked for validity.
     """
     try:
-        opts, args = getopt.getopt(arguments, "hfs:F:S:B:R:e:u:p:P:z:")
+        opts, args = getopt.getopt(arguments, "hfs:F:S:B:R:u:p:P:z:")
     except getopt.GetoptError as err:
         error(str(err)+USAGE)
 
@@ -142,8 +137,6 @@ def parse_command_line_options(arguments):
     }
 
     for option, value in opts:
-        if option == "-e":
-            options['encoding'] = value
         if option == "-s":
             options['sep'] = value
         elif option == "-F":

--- a/test_sending.py
+++ b/test_sending.py
@@ -58,7 +58,6 @@ def test_local_sending():
             '-F', email_from,
             '-S', email_subject,
             '-z', 'localhost',
-            '-e', email_encoding,
             f.name
         ]
         options = massmail.parse_command_line_options(cmd_options)


### PR DESCRIPTION
Fixes #18 